### PR TITLE
Corrigido classe sem inicio maiusculo

### DIFF
--- a/app/Models/Usuarios.php
+++ b/app/Models/Usuarios.php
@@ -5,7 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class usuarios extends Model
+class Usuarios extends Model
 {
     use HasFactory;
 


### PR DESCRIPTION
# mudanças

## Corrigido um bug onde havia um problema no comando ``` composer install``` devido a um nome incorreto de classe